### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update submodules.yml
+++ b/.github/workflows/update submodules.yml
@@ -2,6 +2,8 @@ name: update submodules
 on:
   workflow_call:
   workflow_dispatch:
+permissions:
+  contents: write
 jobs:
   update-submodules:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/okazunori2013-auto/ffmpeg-auto/security/code-scanning/1](https://github.com/okazunori2013-auto/ffmpeg-auto/security/code-scanning/1)

Add an explicit `permissions` block so the workflow does not depend on repository/org defaults.  
Best fix here (without changing functionality): define permissions at the workflow root, since there is only one job and it needs to push commits. Use:

- `contents: write` (required for committing/pushing back to the repo)

This should be inserted in `.github/workflows/update submodules.yml` directly after the `on:` section and before `jobs:`.

No imports, methods, or additional definitions are needed (YAML workflow change only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
