### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,8 @@
 name: build
+permissions:
+  contents: read
+  actions: read
+  packages: read
 concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/okazunori2013-auto/ffmpeg-auto/security/code-scanning/3](https://github.com/okazunori2013-auto/ffmpeg-auto/security/code-scanning/3)

Add an explicit top-level `permissions` block in `.github/workflows/build.yml` so all jobs inherit restricted token scopes unless overridden.

Best single fix without changing existing functionality:
- Insert, near the top of the workflow (after `name:` or after `on:`), a root-level `permissions:` block.
- Start with:
  - `contents: read` (recommended minimum and needed for checkout),
  - `actions: read` (safe for reading workflow/action metadata),
  - `packages: read` (common safe read scope; optional but aligned with GitHub guidance for reusable workflows).
- If later a step fails due to missing write scopes (for example, if a specific action requires them), add only the specific write permission needed at job level. For now, keep global permissions minimal.

No imports/dependencies/methods are needed since this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
